### PR TITLE
Update init.js

### DIFF
--- a/javascript-source/init.js
+++ b/javascript-source/init.js
@@ -679,15 +679,10 @@
       }
     });
 
-    /**
-     * @event initReady
-     */
-    addHook('initReady', function () {
-      $.registerChatCommand('./init.js', 'chat', 1);
-      $.registerChatCommand('./init.js', 'module', 1);
-      $.registerChatCommand('./init.js', 'reconnect', 2);
-    });
-
+    $.registerChatCommand('./init.js', 'chat', 1);
+    $.registerChatCommand('./init.js', 'module', 1);
+    $.registerChatCommand('./init.js', 'reconnect', 2);
+ 
     // emit initReady event
     callHook('initReady', null, true);
   }


### PR DESCRIPTION
Removing the initReady hook in init.js as it is not loaded via loadScriptR API which sets the $script object used by the addHook object.  Now, the registerChatCommand() calls for chat, module and reconnect still function and are loaded:

[02-05-2016 @ 20:17:15] Loaded module: commands/topCommand.js (Enabled)
[02-05-2016 @ 20:17:15] Bot locked & loaded!
[02-05-2016 @ 20:17:15] Trying to add ./init.js | chat
[02-05-2016 @ 20:17:15] Trying to add ./init.js | module
[02-05-2016 @ 20:17:15] Trying to add ./init.js | reconnect

So, this is sort of a kludge, but, not entirely sure it is safe to try to build up a $script object before performing a $.bind('initReady') in init.js.